### PR TITLE
Only build the base image on change

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,14 +6,16 @@ name: Docker
 # documentation.
 
 on:
-  schedule:
-    - cron: '37 18 * * *'
   push:
     branches: [ main ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
+    paths:
+    - 'base_dockerfile/**'
   pull_request:
     branches: [ main ]
+    paths:
+    - 'base_dockerfile/**'
 
 env:
   # Use docker.io for Docker Hub if empty


### PR DESCRIPTION
The base ROS image probably won't change very much and building it is by far the longest CI step. This changeset uses the "paths" arg in the github CI workflow to only build the image on an actual change.