### PR TITLE
Add Back Arm64 Support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -80,7 +80,7 @@ jobs:
         uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8
         with:
           context: ./base_dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/base_dockerfile/Dockerfile
+++ b/base_dockerfile/Dockerfile
@@ -2,17 +2,6 @@ FROM ros:foxy as base
 ARG DEBIAN_FRONTEND=noninteractive
 
 ##########################
-## Rust Install
-##########################
-# Install Dependancies
-RUN apt-get update && apt-get install -y \
-    curl \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.61.0 -y
-ENV PATH=/root/.cargo/bin:$PATH
-
-##########################
 ## ros2_rust install
 ##########################
 # Install Dependancies
@@ -31,5 +20,17 @@ RUN pip install --upgrade pytest colcon-package-selection
 # Install the colcon-cargo and colcon-ros-cargo plugins
 RUN pip install git+https://github.com/colcon/colcon-cargo.git git+https://github.com/colcon/colcon-ros-cargo.git
 
-# Install the cargo-ament-build plugin 
-RUN cargo install --debug cargo-ament-build 
+# Install Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.61.0 -y
+ENV PATH=/root/.cargo/bin:$PATH
+
+# Switch Rust to the nightly build.
+# Note we are currently using the nightly build for the 
+# sparse update feature in crates.io index.
+# Rustup switches to the nightly build
+# See this blog post for more info on the spare-registry feature
+# https://blog.rust-lang.org/2022/06/22/sparse-registry-testing.html
+RUN rustup toolchain install nightly
+
+# Install the cargo-ament-build plugin
+RUN cargo +nightly install -Z sparse-registry --debug cargo-ament-build 

--- a/base_dockerfile/Dockerfile
+++ b/base_dockerfile/Dockerfile
@@ -9,6 +9,8 @@ RUN apt-get update && apt-get install -y \
     python3-vcstool \
     libclang-dev \
     clang \
+    curl \
+    vim \
     python3.9 \
     python3.9-dev \
     python3-pip \


### PR DESCRIPTION
This change finally fixes the cargo-ament-build install and reenables support for the arm64 base image.

The previous problem was that the crates.io updating step was taking too long during the updates on arm64 and causes an out of memory error.

This was resolved with a new feature in cargo: https://blog.rust-lang.org/2022/06/22/sparse-registry-testing.html

We switched to the nightly builds of rust to get this new feature flag and everything is working great. Hopefully this will hit the mainline of cargo + rust soon.